### PR TITLE
Add docu for step cfManifestSubstituteVariables.md

### DIFF
--- a/documentation/docs/steps/cfManifestSubstituteVariables.md
+++ b/documentation/docs/steps/cfManifestSubstituteVariables.md
@@ -1,0 +1,19 @@
+# ${docGenStepName}
+
+## ${docGenDescription}
+
+## Prerequisites
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}
+
+## ${docJenkinsPluginDependencies}
+
+## Side effects
+
+## Exceptions
+
+
+## Example
+

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
         - batsExecuteTests: steps/batsExecuteTests.md
         - checkChangeInDevelopment: steps/checkChangeInDevelopment.md
         - checksPublishResults: steps/checksPublishResults.md
+        - cfManifestSubstituteVariables: steps/cfManifestSubstituteVariables.md
         - cloudFoundryDeploy: steps/cloudFoundryDeploy.md
         - commonPipelineEnvironment: steps/commonPipelineEnvironment.md
         - containerExecuteStructureTests: steps/containerExecuteStructureTests.md


### PR DESCRIPTION
Hi @TheFonz2017. This PR adds the documentation for your new step.

In case you would like to create the docu locally on your side you can use a script which is not contained in the official master branch:  https://github.com/marcusholl/jenkins-library/blob/auxilary/createDocu/createDocu.sh. Just invoke: `./createDocu.sh`
