### PR TITLE
no java doc comment

### DIFF
--- a/vars/cfManifestSubstituteVariables.groovy
+++ b/vars/cfManifestSubstituteVariables.groovy
@@ -120,7 +120,7 @@ void call(Map<String, String> arguments) {
     }
 }
 
-/**
+/*
  * Removes the given file, if it exists.
  * @param filePath the path to the file to remove.
  */


### PR DESCRIPTION
Since we have our home made docu generator we have issues with javadoc like comments at locations where our docu generator does not expect those comments.

We tried to use standard javadoc / groovydoc genertors, but we didd not succeed.

Since in turn there is no additional javadoc generated with a standard javadoc toolset I guess the simplest approach it so "downgrade" the javadoc comment to a normal block comment. 